### PR TITLE
Fix to prevent failures to generate key caused by stale config data

### DIFF
--- a/src/KeyGenerateCommand.php
+++ b/src/KeyGenerateCommand.php
@@ -104,7 +104,7 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = preg_quote('='.env('APP_KEY'), '/');
 
         return "/^APP_KEY{$escaped}/m";
     }


### PR DESCRIPTION
I have encountered a very unstable key:generate call while creating a setup command for a laravel app i'm working on.

My script basically copies over the .env.example then runs config:clear and config:cache then key:generate

Half the time it fails. For instance if it succeeds the first time then you close the script. Delete your .env run the script again, the app is in a state where somehow in the $this->larvavel['config']['app.key'] it has the old key, yet the .env is now a fresh copy of the .env.example and it fails hard. it can't replace it.

anyways. i found after changing this to pull from the env() record instead, the issue is no more.
The function description also seems to refer to it as env APP_KEY as well.

"Get a regex pattern that will match env APP_KEY with any random key."

I have been banging my head with this for hours before discovering this. cheers!